### PR TITLE
updates to android plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,11 @@ $ ionic platform add android
 ```
 -> substitute android with ios to build for iOS.
 
+-> substitute ionic with cordova to build on cordova.
+
 ### 1. Download or clone this project, copy it to your app root folder and run ionic command to add the plugin:
+
+#### Ionic 
 ```bash
 $ git clone https://github.com/gustavomazzoni/cordova-plugin-tesseract
 $ cp -rf cordova-plugin-tesseract your-project/cordova-plugin-tesseract
@@ -27,68 +31,14 @@ $ cd your-project/
 $ ionic plugin add cordova-plugin-tesseract
 ```
 
+#### Cordova
+
+```bash
+$ cordova plugin add https://github.com/gustavomazzoni/cordova-plugin-tesseract
+```
+
+
 ### 2. For Android platform:
-
-#### 2.1 Download or clone [tess-two project](https://github.com/rmtheis/tess-two) (it contains Tesseract library for Android) and copy the 'tess-two' folder inside of it to your android platform:
-```bash
-$ git clone https://github.com/rmtheis/tess-two
-$ cp -rf tess-two/tess-two/ your-project/platforms/android/tess-two
-```
-
-#### 2.2 Edit `your-project/platforms/android/tess-two/build.gradle` and replace all content with:
-```bash
-buildscript {
-    repositories {
-        mavenCentral()
-    }
-    dependencies {
-        classpath 'com.android.tools.build:gradle:0.14.0'
-    }
-}
-
-apply plugin: 'android-library'
-
-android {
-    compileSdkVersion 23
-    buildToolsVersion "23.0.2"
-
-    defaultConfig {
-        minSdkVersion 8
-        targetSdkVersion 23
-    }
-
-    sourceSets.main {
-        manifest.srcFile 'AndroidManifest.xml'
-        java.srcDirs = ['src']
-        resources.srcDirs = ['src']
-        res.srcDirs = ['res']
-        jniLibs.srcDirs = ['libs']
-    }
-}
-```
-
-#### 2.3 Edit `your-project/platforms/android/build.gradle` file and add 'tess-two' as a dependency to your project (after `// SUB-PROJECT DEPENDENCIES END` line):
-```bash
-dependencies {
-    compile fileTree(dir: 'libs', include: '*.jar')
-    // SUB-PROJECT DEPENDENCIES START
-    debugCompile project(path: "CordovaLib", configuration: "debug")
-    releaseCompile project(path: "CordovaLib", configuration: "release")
-    // SUB-PROJECT DEPENDENCIES END
-    compile project(':tess-two')
-}
-```
-
-#### 2.4 Edit `your-project/platforms/android/cordova/lib/build.js` file that generates `settings.gradle` file:
-
-* Edit `your-project/platforms/android/cordova/lib/builders/GradleBuilder.js` and replace the `fs.writeFileSync()` function call after `// Write the settings.gradle file.` (at line 101) with:
-```bash
-//##### EDITED - Added tess-two library dependency
-fs.writeFileSync(path.join(this.root, 'settings.gradle'),
-    '// GENERATED FILE - DO NOT EDIT\n' +
-    'include ":"\n' + settingsGradlePaths.join('') +
-    'include ":tess-two"');
-```
 
 #### 2.5 Your project is ready to use this plugin on Android platform. Build your project:
 ```bash
@@ -130,7 +80,10 @@ cordova-plugin-tesseract is designed to recognize text in images in many languag
 To use this plugin and recognize text in images, you need to:
 
 ### 1. Download the language
-As soon as you enter on your OCR use case, call `TesseractPlugin.loadLanguage` function to download the tessdata for your language:
+As soon as you enter on your OCR use case, call `TesseractPlugin.loadLanguage` function to download the tessdata for your language.
+
+Language must be in format like `eng` . For a list of compatible languages check [this link](https://github.com/tesseract-ocr/tessdata/tree/3.04.00).
+
 ```bash
 TesseractPlugin.loadLanguage(language, function(response) {
   deferred.resolve(response);

--- a/package.json
+++ b/package.json
@@ -1,7 +1,32 @@
 {
-  "name": "cordova-plugin-tesseract",
-  "version": "0.0.1",
-  "description": "\n\t\tThis plugin allows to recognise text from images\n\t",
+  "_from": "git+https://github.com/gustavomazzoni/cordova-plugin-tesseract.git",
+  "_id": "cordova-plugin-tesseract@0.0.1",
+  "_inBundle": false,
+  "_integrity": "",
+  "_location": "/cordova-plugin-tesseract",
+  "_phantomChildren": {},
+  "_requested": {
+    "type": "git",
+    "raw": "https://github.com/gustavomazzoni/cordova-plugin-tesseract",
+    "rawSpec": "https://github.com/gustavomazzoni/cordova-plugin-tesseract",
+    "saveSpec": "git+https://github.com/gustavomazzoni/cordova-plugin-tesseract.git",
+    "fetchSpec": "https://github.com/gustavomazzoni/cordova-plugin-tesseract.git",
+    "gitCommittish": null
+  },
+  "_requiredBy": [
+    "#USER",
+    "/"
+  ],
+  "_resolved": "git+https://github.com/gustavomazzoni/cordova-plugin-tesseract.git#e909e00977161e53d905ffaf78dd5b92e497dcee",
+  "_spec": "https://github.com/gustavomazzoni/cordova-plugin-tesseract",
+  "_where": "/home/varun/dev/ocr/node_modules",
+  "author": {
+    "name": "gustavomazzoni"
+  },
+  "bugs": {
+    "url": "https://github.com/gustavomazzoni/cordova-plugin-tesseract#issues"
+  },
+  "bundleDependencies": false,
   "cordova": {
     "id": "cordova-plugin-tesseract",
     "platforms": [
@@ -9,15 +34,8 @@
       "android"
     ]
   },
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/gustavomazzoni/cordova-plugin-tesseract.git"
-  },
-  "keywords": [
-    "ecosystem:cordova",
-    "cordova-ios",
-    "cordova-android"
-  ],
+  "deprecated": false,
+  "description": "\n\t\tThis plugin allows to recognise text from images\n\t",
   "engines": [
     {
       "name": "cordova",
@@ -28,10 +46,17 @@
       "version": ">=3.6.0"
     }
   ],
-  "author": " gustavomazzoni",
+  "homepage": "https://github.com/gustavomazzoni/cordova-plugin-tesseract#readme",
+  "keywords": [
+    "ecosystem:cordova",
+    "cordova-ios",
+    "cordova-android"
+  ],
   "license": "MIT",
-  "bugs": {
-    "url": "https://github.com/gustavomazzoni/cordova-plugin-tesseract#issues"
+  "name": "cordova-plugin-tesseract",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/gustavomazzoni/cordova-plugin-tesseract.git"
   },
-  "homepage": "https://github.com/gustavomazzoni/cordova-plugin-tesseract#readme"
+  "version": "0.0.1"
 }

--- a/plugin.xml
+++ b/plugin.xml
@@ -1,18 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
-
-<plugin xmlns="http://apache.org/cordova/ns/plugins/1.0"
-           id="cordova-plugin-tesseract"
-      version="0.0.1">
+<plugin 
+    xmlns="http://apache.org/cordova/ns/plugins/1.0" id="cordova-plugin-tesseract" version="0.0.1">
     <name>Tesseract Plugin</name>
-    
     <engines>
-        <engine name="cordova-android" version=">=3.6.0" /><!-- Requires CordovaPlugin.preferences -->
+        <engine name="cordova-android" version=">=3.6.0" />
+        <!-- Requires CordovaPlugin.preferences -->
     </engines>
-
     <js-module src="www/tesseractPlugin.js" name="TesseractPlugin">
         <clobbers target="TesseractPlugin" />
     </js-module>
-
     <!-- android -->
     <platform name="android">
         <config-file target="res/xml/config.xml" parent="/*">
@@ -20,20 +16,18 @@
                 <param name="android-package" value="com.gmazzoni.cordova.TesseractPlugin"/>
             </feature>
         </config-file>
-
+        <!-- <asset src="tessdata" target="tessdata" /> -->
+        <framework src="com.rmtheis:tess-two:9.0.0" />
         <source-file src="src/android/TesseractPlugin.java" target-dir="src/com/tesseract/phonegap" />
     </platform>
-
-
     <!-- ios -->
     <platform name="ios">
         <config-file target="config.xml" parent="/*">
-		    <feature name="TesseractPlugin">
-			    <param name="ios-package" value="TesseractPlugin"/>
+            <feature name="TesseractPlugin">
+                <param name="ios-package" value="TesseractPlugin"/>
                 <param name="onload" value="true" />
-		    </feature>
+            </feature>
         </config-file>
-
         <header-file src="src/ios/claseAuxiliar.h" />
         <source-file src="src/ios/claseAuxiliar.mm" />
         <header-file src="src/ios/TesseractPlugin.h" />
@@ -41,6 +35,4 @@
         <!-- set the tessdata directory as a resource so it can go with the app -->
         <resource-file src="tessdata" />
     </platform>
-    
-
 </plugin>

--- a/src/android/TesseractPlugin.java
+++ b/src/android/TesseractPlugin.java
@@ -118,9 +118,15 @@ public class TesseractPlugin extends CordovaPlugin {
             Log.v(TAG, "couldn't find tessdata, downloading");
             DownloadAndCopy job = new DownloadAndCopy();
             job.execute(lang);
+            try {
+            job.get(); //wait for download to complete
+            } catch (Exception e) {
+                Log.v(TAG, "download task interrupted");
+                e.printStackTrace();
+                return "Interrupted";
+            }
         } else 
             Log.v(TAG, "Found existing tessdata");
-
         return "Ok";
     }
 

--- a/src/android/TesseractPlugin.java
+++ b/src/android/TesseractPlugin.java
@@ -3,6 +3,7 @@ package com.gmazzoni.cordova;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
+import java.io.BufferedInputStream;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.net.URL;
@@ -83,6 +84,8 @@ public class TesseractPlugin extends CordovaPlugin {
         baseApi.setImage(bitmap);
 
         String recognizedText = "";
+        Log.v(TAG, "calling baseApi.getUTF8Text()");
+
         recognizedText = baseApi.getUTF8Text();
 
         baseApi.end();
@@ -112,9 +115,12 @@ public class TesseractPlugin extends CordovaPlugin {
         }
 
         if (!(new File(DATA_PATH + "tessdata/" + lang + ".traineddata")).exists()) {
+            Log.v(TAG, "couldn't find tessdata, downloading");
             DownloadAndCopy job = new DownloadAndCopy();
             job.execute(lang);
-        }
+        } else 
+            Log.v(TAG, "Found existing tessdata");
+
         return "Ok";
     }
 
@@ -126,20 +132,24 @@ public class TesseractPlugin extends CordovaPlugin {
             // do above Server call here
             try {
                 Log.v(TAG, "Downloading " + lang + ".traineddata");
-                URL url = new URL("https://cdn.rawgit.com/naptha/tessdata/gh-pages/3.02/"+lang+".traineddata.gz");
-                GZIPInputStream gzip = new GZIPInputStream(url.openStream());
-                Log.v(TAG, "Downloaded and unziped " + lang + ".traineddata");
+                // tess two now supports tessdata 3.04, and switching to official repo 
+                String stringURL = "https://github.com/tesseract-ocr/tessdata/raw/3.04.00/" + lang + ".traineddata";
+                Log.v(TAG, "downloading from url " + stringURL);
+                URL url = new URL(stringURL);
 
+		InputStream input = new BufferedInputStream(url.openStream(), 8192);
+                   		
+			
                 OutputStream out = new FileOutputStream(DATA_PATH
                         + "tessdata/" + lang + ".traineddata");
 
                 byte[] buf = new byte[1024];
                 int len;
-                while ((len = gzip.read(buf)) > 0) {
+                while ((len = input.read(buf)) > 0) {
                     out.write(buf, 0, len);
                 }
 
-                gzip.close();
+                input.close();
                 out.close();
 
                 Log.v(TAG, "Copied " + lang + ".traineddata");


### PR DESCRIPTION
Added dependency `com.rmtheis:tess-two:9.0.0` in plugin.xml avoiding installation steps in android.
Upgraded tessdata from 3.02 from 3.04 and from official repo: https://github.com/tesseract-ocr/tessdata/raw/3.04.00/.
Updated readme.

Signed-off-by: Varun Garg <varun.10@live.com>